### PR TITLE
Fixed: All Broken link to dev_notes.md in the documentation

### DIFF
--- a/contributor_docs/friendly_error_system.md
+++ b/contributor_docs/friendly_error_system.md
@@ -135,10 +135,10 @@ These functions are mainly responsible for catching errors and generating FES me
 
 For full reference, please see our [Dev Notes].
 
-[`_friendlyFileLoadError()`]: https://github.com/processing/p5.js/blob/main/contributor_docs/zh-Hans/fes_reference_dev_notes.md#_friendlyfileloaderror
-[`_validateParameters()`]: https://github.com/processing/p5.js/blob/main/contributor_docs/zh-Hans/fes_reference_dev_notes.md#validateparameters
-[`_fesErrorMonitor()`]: https://github.com/processing/p5.js/blob/main/contributor_docs/zh-Hans/fes_reference_dev_notes.md#feserrormonitor
-[Dev Notes]: https://github.com/processing/p5.js/blob/main/contributor_docs/zh-Hans/fes_reference_dev_notes.md
+[`_friendlyFileLoadError()`]: https://github.com/processing/p5.js/blob/main/contributor_docs/fes_contribution_guide.md#_friendlyerror
+[`_validateParameters()`]: https://github.com/processing/p5.js/blob/main/contributor_docs/fes_contribution_guide.md#_validateParameters
+[`_fesErrorMonitor()`]: https://github.com/processing/p5.js/blob/main/contributor_docs/fes_contribution_guide.md#feserrormonitor
+[Dev Notes]: https://github.com/processing/p5.js/blob/main/contributor_docs/fes_contribution_guide.md#-development-notes
 
 
 #### FES Message Displayer


### PR DESCRIPTION
Fixed the Chinese version link and new url
<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #7083" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #7083 ".-->
Resolves #7083 

#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ ] `npm run lint` passes
- [ ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
